### PR TITLE
Disabled stylecheck and gocritic linters

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,4 +1,4 @@
 [linters]
 enable-all = true
 # Megacheck and Typecheck seem to have a lot of difficulty with go modules, atm:
-disable = [ "megacheck", "typecheck" ]
+disable = [ "megacheck", "typecheck", "stylecheck", "gocritic" ]


### PR DESCRIPTION
Disabling stylecheck and gocritic linters to fix downstream build failures in runtime-tools