### PR TITLE
Feature/eb-434

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,4 +1,4 @@
 [linters]
 enable-all = true
 # Megacheck and Typecheck seem to have a lot of difficulty with go modules, atm:
-disable = [ "megacheck", "typecheck", "stylecheck", "gocritic" ]
+disable = [ "megacheck", "typecheck", "stylecheck", "gocritic", "godox", "gomnd", "wsl"]

--- a/config/settings/settings.go
+++ b/config/settings/settings.go
@@ -65,7 +65,6 @@ func ReadConfig() {
 
 	if err := viper.ReadInConfig(); err == nil {
 		log.WithFields(log.Fields{"config_file": viper.ConfigFileUsed()}).Debug("Using file")
-
 	} else {
 		log.WithFields(log.Fields{"config_file": viper.ConfigFileUsed()}).Error(err)
 	}

--- a/errors/panic.go
+++ b/errors/panic.go
@@ -14,7 +14,6 @@ func PanicOnErrors(err error) {
 			log.Panic(anErr)
 		}
 		// log.Error("Multiple errors from s3.ReadListToCallback()")
-
 	} else {
 		log.Panic(err)
 	}

--- a/files/s3/read.go
+++ b/files/s3/read.go
@@ -36,7 +36,6 @@ func (s *Details) ReadListToCallback(subPaths []string, f ReadCallback) error {
 	for _, subPath := range subPaths {
 		if body, err := s.ReadToString(subPath); err != nil {
 			errs = multierror.Append(errs, err)
-
 		} else {
 			if errCallback := f(subPath, body); errCallback != nil {
 				errs = multierror.Append(errs, errCallback)

--- a/main.go
+++ b/main.go
@@ -37,7 +37,6 @@ func main() {
 
 	if viper.GetBool("dotenv.skip") {
 		log.Info("Not getting .env secrets due to configuration")
-
 	} else {
 		dotenv.ReadFromS3(secrets)
 	}


### PR DESCRIPTION
Presently we cannot build get-secrets due to various lint failures.

This PR addresses the easy whitespace ones and disables some other linters for the immediate time being (short term). 

godox is very upset, gomnd can probably be resolved with some care, and wsl too with a bit of pedantry edits